### PR TITLE
test: speedup test suit by reusing costly vars (#4384)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,14 +66,25 @@ def xonsh_events():
         setattr(events, name, newevent)
 
 
+@pytest.fixture(scope="session")
+def session_vars():
+    """keep costly vars per session"""
+    from xonsh.environ import Env, default_env
+    from xonsh.commands_cache import CommandsCache
+
+    return {
+        "execer": Execer(unload=False),
+        "env": Env(default_env()),
+        "commands_cache": CommandsCache(),
+    }
+
+
 @pytest.fixture
-def xonsh_builtins(monkeypatch, xonsh_events):
+def xonsh_builtins(monkeypatch, xonsh_events, session_vars):
     """Mock out most of the builtins xonsh attributes."""
     old_builtins = set(dir(builtins))
-    XSH.load(
-        execer=Execer(unload=False),
-        ctx={},
-    )
+
+    XSH.load(ctx={}, **session_vars)
     if ON_WINDOWS:
         XSH.env["PATHEXT"] = [".EXE", ".BAT", ".CMD"]
 

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -580,7 +580,11 @@ class XonshSession:
         self.subproc_captured_hiddenobject = subproc_captured_hiddenobject
         self.subproc_uncaptured = subproc_uncaptured
         self.execer = execer
-        self.commands_cache = CommandsCache()
+        self.commands_cache = (
+            kwargs.pop("commands_cache")
+            if "commands_cache" in kwargs
+            else CommandsCache()
+        )
         self.all_jobs = {}
         self.ensure_list_of_strs = ensure_list_of_strs
         self.list_of_strs_or_callables = list_of_strs_or_callables


### PR DESCRIPTION
* test: speedup test suit by reusing costly vars

* chore: revert changes to xonsh_execer fixture

* revert changes to test_parser

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
