### PR TITLE
Don't modify XONSHRC and XONSHRC_DIR during startup (#4408)

### DIFF
--- a/news/xonshrc-env-4394.rst
+++ b/news/xonshrc-env-4394.rst
@@ -1,0 +1,30 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* The environment variables ``XONSHRC`` and ``XONSHRC_DIR`` are no longer updated by xonsh on
+  startup according to which files were actually loaded. This caused problems if xonsh is called
+  recursively, as the child shells would inherit the modified startup environment of the parent.
+  These variables will now be left untouched, and the actual RC files loaded (according to those
+  variables and command line arguments) can be seen in the output of ``xonfig``.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* The environment variable ``LOADED_RC_FILES`` is no longer set. It contained a list of booleans
+  as to which RC files had been successfully loaded, but it required knowledge of the RC loading
+  internals to interpret which status corresponded to which file. As above, the (successfully)
+  loaded RC files are now shown in ``xonfig``.
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/xonsh/built_ins.py
+++ b/xonsh/built_ins.py
@@ -534,6 +534,7 @@ class XonshSession:
         self.history = None
         self.shell = None
         self.env = None
+        self.rc_files = None
 
     def load(self, execer=None, ctx=None, **kwargs):
         """Loads the session with default values.

--- a/xonsh/main.py
+++ b/xonsh/main.py
@@ -320,7 +320,7 @@ def start_services(shell_kwargs, args, pre_env=None):
         rcd = env.get("XONSHRC_DIR")
 
     events.on_pre_rc.fire()
-    xonshrc_context(
+    XSH.rc_files = xonshrc_context(
         rcfiles=rc, rcdirs=rcd, execer=execer, ctx=ctx, env=env, login=login
     )
     events.on_post_rc.fire()

--- a/xonsh/xonfig.py
+++ b/xonsh/xonfig.py
@@ -552,6 +552,7 @@ def _info(ns):
     data.extend([("on jupyter", jup_ksm is not None), ("jupyter kernel", jup_kernel)])
 
     data.extend([("xontrib", xontribs_loaded())])
+    data.extend([("RC file", XSH.rc_files)])
 
     formatter = _xonfig_format_json if ns.json else _xonfig_format_human
     s = formatter(data)


### PR DESCRIPTION
* xonshrc_context: return loaded instead of context, don't touch env

This function returned the context, but the return value is not used by
the sole call site (and would inconsistently be either the env or ctx
depending on other arguments). Redefine the function to return what was
loaded.

The function will also no longer touch the environment variables
XONSHRC, XONSHRC_DIR or LOADED_RC_FILES.

* XonshSession: add rc_files list, and set in start_services

* LOADED_RC_FILES: drop completely

* xonfig: add RC files

* test_main: update tests for changes to XONSHRC{,_DIR}

* news: add entry for xonshrc changes

<!--- Thanks for opening a PR on xonsh! Please include a news entry with your PR
to help keep our changelog up to date! There are instructions available here:
https://xon.sh/devguide.html#changelog -->

<!--- If there is specific issue / feature request that this PR is addressing,
please link to the corresponding issue by using the `#issuenumber` syntax.
Thanks again! -->

## For community
⬇️  **Please click the 👍 reaction instead of leaving a `+1` or 👍  comment**
